### PR TITLE
Fix misplaced parenthesis in findAndReplace exclude check

### DIFF
--- a/static/js/copy_paste_select_all.js
+++ b/static/js/copy_paste_select_all.js
@@ -35,7 +35,7 @@ const findAndReplace = (searchText, replacement, searchNode) => {
   while (cnLength--) {
     const currentNode = childNodes[cnLength];
     if (currentNode.nodeType === 1) {
-      if (excludes.indexOf(currentNode.nodeName.toLowerCase() === -1)) {
+      if (excludes.indexOf(currentNode.nodeName.toLowerCase()) === -1) {
         findAndReplace(searchText, replacement, currentNode);
       }
     }


### PR DESCRIPTION
Found during a systematic audit of all Etherpad plugins.

🤖 Generated with [Claude Code](https://claude.com/claude-code)