### PR TITLE
fix: backward-compat for ESM etherpad

### DIFF
--- a/copy_paste_select_all.js
+++ b/copy_paste_select_all.js
@@ -1,6 +1,6 @@
 'use strict';
 
-const eejs = require('ep_etherpad-lite/node/eejs/');
+const eejs = require('ep_etherpad-lite/node/eejs');
 
 exports.eejsBlock_dd_edit = (hookName, args, cb) => {
   args.content += eejs.require('ep_copy_paste_select_all/templates/copy_paste_select_all_menu.ejs');

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ep_copy_paste_select_all",
-  "version": "0.0.61",
+  "version": "0.0.62",
   "keywords": [
     "select all",
     "copy",


### PR DESCRIPTION
This PR makes the plugin backward-compatible with the upcoming ESM etherpad branch (ether/etherpad#7605).

**Change:** Remove trailing slash from `require("ep_etherpad-lite/node/eejs/")` → `require("ep_etherpad-lite/node/eejs")`

The trailing-slash form breaks under Node's strict ESM exports map resolution. This change is **backward-compatible** with the current CJS etherpad release.